### PR TITLE
Add keybindings and custom close tag command.

### DIFF
--- a/extensions/jsx.yaml
+++ b/extensions/jsx.yaml
@@ -20,16 +20,17 @@ contexts: !merge
         - expression
 
   jsx-expect-tag-end:
+    - meta_content_scope: meta.tag.js
     - match: '>'
-      scope: punctuation.definition.tag.end.js
+      scope: meta.tag.js punctuation.definition.tag.end.js
       pop: true
     - include: else-pop
 
   jsx-tag:
     - match: '<'
-      scope: punctuation.definition.tag.begin.js
+      scope: meta.tag.js punctuation.definition.tag.begin.js
       set:
-      - meta_scope: meta.tag.js
+      - meta_content_scope: meta.tag.js
       - match: '/'
         scope: punctuation.definition.tag.begin.js
         set:
@@ -44,7 +45,7 @@ contexts: !merge
           - jsx-tag-name
 
   jsx-tag-attributes:
-    - meta_scope: meta.tag.js
+    - meta_content_scope: meta.tag.js
 
     - match: '>'
       scope: punctuation.definition.tag.end.js
@@ -96,6 +97,14 @@ contexts: !merge
         2: punctuation.definition.entity.js
 
   jsx-tag-name:
+    - match: ''
+      set:
+        - - clear_scopes: 1
+          - meta_scope: meta.tag.name.js
+          - include: immediately-pop
+        - jsx-tag-name-component
+
+  jsx-tag-name-component:
     - match: '{{jsx_identifier}}'
       scope: entity.name.tag.js
       set:
@@ -112,9 +121,9 @@ contexts: !merge
     - match: (?=<)
       set:
         - match: '<'
-          scope: punctuation.definition.tag.begin.js
+          scope: meta.tag.js punctuation.definition.tag.begin.js
           set:
-            - meta_scope: meta.tag.js
+            - meta_content_scope: meta.tag.js
 
             - match: '/'
               scope: punctuation.definition.tag.begin.js
@@ -124,7 +133,8 @@ contexts: !merge
 
             - match: (?=\S)
               set:
-                - jsx-body
+                - - match: ''
+                    set: jsx-body
                 - jsx-tag-attributes
                 - jsx-tag-name
 

--- a/jsx_close_tag_command.py
+++ b/jsx_close_tag_command.py
@@ -1,0 +1,82 @@
+import sublime
+import sublime_plugin
+
+TAG_BEGIN_SCOPE = 'punctuation.definition.tag.begin.js'
+TAG_END_SCOPE = 'punctuation.definition.tag.end.js'
+
+class JsxCloseTagCommand(sublime_plugin.TextCommand):
+    def run(self, edit, **kwargs):
+        for region in reversed(self.view.sel()):
+            pos = region.begin()
+            try:
+                open_tag = self.find_open_tag(pos)
+                self.view.insert(edit, pos, '/%s>' % open_tag)
+            except ValueError:
+                self.view.insert(edit, pos, '/')
+
+    def find_open_tag(self, end):
+        depth = 0
+        while True:
+            tag_end = self.find_before(TAG_END_SCOPE, end)
+
+            scope = self.view.scope_name(tag_end)
+            target_scope = scope.replace(TAG_END_SCOPE, TAG_BEGIN_SCOPE)
+
+            tag_begin = self.find_before(target_scope, tag_end)
+            if self.view.substr(tag_begin) == '/':
+                tag_begin = self.find_before(target_scope, tag_begin)
+
+            end = tag_begin
+
+            # Handle self-closing tag
+            last_token = self.find_before('- comment', tag_end)
+            if self.view.substr(last_token) == '/':
+                # print('self-closing')
+                continue
+
+            # Handle close tag
+            first_token = self.find_after('- comment', tag_begin)
+            if self.view.substr(first_token) == '/':
+                # print('close')
+                depth += 1
+                continue
+
+            # Else, open tag
+
+            if depth == 0:
+                # print('found!')
+
+                if self.view.match_selector(first_token, 'meta.tag.name'):
+                    name_end = self.find_after('- meta.tag.name', first_token)
+                    name_region = sublime.Region(first_token, name_end)
+                    name = self.view.substr(name_region).strip()
+                    # print('['+name+']')
+                    return name
+                else:
+                    # Fragment, or invalid
+                    return ''
+            else:
+                # print('open')
+                depth -= 1
+                continue
+
+    def find_before(self, selector, pos):
+        pos -= 1
+        while pos >= 0:
+            if self.view.match_selector(pos, selector):
+                return pos
+            else:
+                pos -= 1
+        
+        raise ValueError("Can't find open tag.")
+
+    def find_after(self, selector, pos):
+        pos += 1
+        max = self.view.size()
+        while pos <= max:
+            if self.view.match_selector(pos, selector):
+                return pos
+            else:
+                pos += 1
+        
+        raise ValueError("Can't find open tag.")

--- a/jsx_close_tag_command.py
+++ b/jsx_close_tag_command.py
@@ -5,14 +5,16 @@ TAG_BEGIN_SCOPE = 'punctuation.definition.tag.begin.js'
 TAG_END_SCOPE = 'punctuation.definition.tag.end.js'
 
 class JsxCloseTagCommand(sublime_plugin.TextCommand):
-    def run(self, edit, **kwargs):
+    def run(self, edit, insert_slash=False):
         for region in reversed(self.view.sel()):
             pos = region.begin()
             try:
                 open_tag = self.find_open_tag(pos)
-                self.view.insert(edit, pos, '/%s>' % open_tag)
+                text = '%s/%s>' % ('' if insert_slash else '<', open_tag)
+                self.view.insert(edit, pos, text)
             except ValueError:
-                self.view.insert(edit, pos, '/')
+                if insert_slash:
+                    self.view.insert(edit, pos, '/')
 
     def find_open_tag(self, end):
         depth = 0
@@ -31,32 +33,25 @@ class JsxCloseTagCommand(sublime_plugin.TextCommand):
             # Handle self-closing tag
             last_token = self.find_before('- comment', tag_end)
             if self.view.substr(last_token) == '/':
-                # print('self-closing')
                 continue
 
             # Handle close tag
             first_token = self.find_after('- comment', tag_begin)
             if self.view.substr(first_token) == '/':
-                # print('close')
                 depth += 1
                 continue
 
             # Else, open tag
-
             if depth == 0:
-                # print('found!')
-
                 if self.view.match_selector(first_token, 'meta.tag.name'):
                     name_end = self.find_after('- meta.tag.name', first_token)
                     name_region = sublime.Region(first_token, name_end)
                     name = self.view.substr(name_region).strip()
-                    # print('['+name+']')
                     return name
                 else:
                     # Fragment, or invalid
                     return ''
             else:
-                # print('open')
                 depth -= 1
                 continue
 

--- a/jsx_close_tag_listener.py
+++ b/jsx_close_tag_listener.py
@@ -1,0 +1,9 @@
+import sublime
+import sublime_plugin
+
+class JsxCloseTagListener(sublime_plugin.ViewEventListener):
+    def on_text_command(self, command_name, args):
+        if command_name != 'close_tag': return
+        if not self.view.match_selector(0, 'source.js'): return
+
+        return ('jsx_close_tag', args)

--- a/jsx_close_tag_listener.py
+++ b/jsx_close_tag_listener.py
@@ -5,5 +5,6 @@ class JsxCloseTagListener(sublime_plugin.ViewEventListener):
     def on_text_command(self, command_name, args):
         if command_name != 'close_tag': return
         if not self.view.match_selector(0, 'source.js'): return
+        if not sublime.load_settings('JS Custom.sublime-settings').get('jsx_close_tag', False): return
 
         return ('jsx_close_tag', args)

--- a/sublime/Default.sublime-keymap
+++ b/sublime/Default.sublime-keymap
@@ -1,0 +1,76 @@
+// Derived from the Default package and from babel-sublime.
+[
+    // Auto-pair backticks
+    { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`$0`"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js - string" },
+
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|>|$)", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true }
+        ]
+    },
+    { "keys": ["`"], "command": "insert_snippet", "args": {"contents": "`${0:$SELECTION}`"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js - string" },
+
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+        ]
+    },
+    { "keys": ["`"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js" },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true },
+        ]
+    },
+    { "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete Left Right.sublime-macro"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "punctuation.definition.string.begin", "match_all": true },
+            { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single - punctuation.definition.string.end", "match_all": true },
+        ]
+    },
+
+    // Auto-pair interpolation
+    { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.js string.template.js", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\$$", "match_all": true }
+        ]
+    },
+    { "keys": ["$"], "command": "insert_snippet", "args": {"contents": "\\${${0:$SELECTION}}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js string.template.js - meta.template.expression.js", "match_all": true },
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true }
+        ]
+    },
+
+    // JSX close tag (inside JSX)
+    { "keys": ["/"], "command": "jsx_close_tag", "args": { "insert_slash": true }, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.js meta.tag.js - meta.embedded.expression - string - comment", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_match", "operand": ".*<$", "match_all": true },
+            { "key": "setting.auto_close_tags" }
+        ]
+    },
+    // // JSX close tag (outer-most tag)
+    // { "keys": ["/"], "command": "close_tag", "args": { "insert_slash": true }, "context":
+    //     [
+    //         { "key": "selector", "operator": "equal", "operand": "source.js - string - comment", "match_all": true },
+    //         { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s*<$", "match_all": true },
+    //         { "key": "setting.auto_close_tags" }
+    //     ]
+    // }
+]

--- a/sublime/JS Custom.sublime-settings
+++ b/sublime/JS Custom.sublime-settings
@@ -16,5 +16,6 @@
         }
     },
 
-    "auto_build": true
+    "auto_build": true,
+    "jsx_close_tag": true
 }


### PR DESCRIPTION
Added keybindings based on the Babel package. Also added a `jsx_close_tag` command, and hooked it in so that it will be invoked instead of the default `close_tag` within `source.js`.