### PR TITLE
New `embed_configuration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ An object containing one or more named configurations. The keys should be the na
 
 An object specifying default [syntax options](#syntax-options) that will apply to all of your syntaxes. Your named configurations will override these defaults.
 
+### `embed_configuration`: object
+
+An object specifying a configuration to use when another syntax embeds the `source.js` scope.
+
 ### `auto_build`: boolean
 
 If true, JS Custom will automatically rebuild your syntaxes when you modify your user settings. Only syntaxes whose configurations have changed will be rebuilt. If `auto_build` is disabled, you will have to run the rebuild command manually.
@@ -109,6 +113,8 @@ Then, if you use “JS Custom - My Config” to highlight the following code, th
 ```js
 const myStyle = style`div { color: red }`;
 ```
+
+By default, the special `embed_configuration` disables this to avoid syntax recursion errors.
 
 ### Metadata
 

--- a/build_js_custom_syntaxes.py
+++ b/build_js_custom_syntaxes.py
@@ -63,9 +63,13 @@ def merge(*dicts):
 
 def get_configurations():
     defaults = SETTINGS.get('defaults', {})
+
     return {
         name: merge(defaults, config)
-        for name, config in SETTINGS.get('configurations', {}).items()
+        for name, config in merge(
+            { '~embed': SETTINGS.get('embed_configuration', {}) },
+            SETTINGS.get('configurations', {})
+        ).items()
     }
 
 def auto_build():

--- a/extensions/custom_template_tags.yaml
+++ b/extensions/custom_template_tags.yaml
@@ -24,14 +24,12 @@ contexts: !merge
         - - clear_scopes: 1
           - include: immediately-pop
         - - match: ''
-            set:
-              - include: !argument include
+            set: !argument include
             with_prototype:
               - match: (?=`)
                 pop: true
               - match: '\$\{'
-                captures:
-                  0: punctuation.definition.template-expression.begin.js
+                scope: punctuation.definition.template-expression.begin.js
                 push:
                   - clear_scopes: 1
                   - meta_scope: meta.template.expression.js

--- a/src/macros.py
+++ b/src/macros.py
@@ -13,13 +13,15 @@ def include_resource(resource):
         arguments={ "file_path": resource },
     )
 
+def has_value(val):
+    return val is not None and val is not False
 
 def get_extensions(node, eval, arguments):
     return [
         include_resource(file_path)
         for file_path in sublime.find_resources('*.yaml')
         if path.dirname(file_path).endswith('Packages/JSCustom/extensions')
-        and arguments.get(path.splitext(path.basename(file_path))[0], None)
+        and has_value(arguments.get(path.splitext(path.basename(file_path))[0], None))
     ]
 
 get_extensions.raw = True

--- a/sublime/JS Custom.sublime-settings
+++ b/sublime/JS Custom.sublime-settings
@@ -1,8 +1,7 @@
 {
     "defaults": {
         "comma_operator": false,
-        "custom_tagged_literals": false,
-        "es_decorators": true,
+        "custom_template_tags": false,
         "flow_types": false,
         "jsx": false,
     },
@@ -14,6 +13,13 @@
             "flow_types": true,
             "jsx": true,
         }
+    },
+
+    "embed_configuration": {
+        "name": "JS Custom (Embedded)",
+        "hidden": true,
+        "file_extensions": [],
+        "custom_template_tags": false,
     },
 
     "auto_build": true,


### PR DESCRIPTION
When another syntax embeds or includes `scope:source.js`, it will find the last matching syntax in lexicographical order. Most of the time, this will be one of your JS Custom configurations.

This PR introduces a new builtin configuration named `~embed`. The syntax compiled from this configuration will be loaded last, and syntaxes that embed `scope:source.js` will embed this one. By default, this configuration disables `custom_template_tags`, which should avoid the recursion errors that have been popping up (#17).