### PR TITLE
Handle arrow function return type declarations.

### DIFF
--- a/extensions/flow_types.yaml
+++ b/extensions/flow_types.yaml
@@ -3,6 +3,20 @@
 ---
 !merge
 variables: !merge
+  arrow_func_lookahead: |-
+    (?x)(?:
+      \s*(async\s*)?
+      (?:
+        {{identifier}}
+        |\( (?: [^()]|\([^()]*\) )* \)
+      )
+      (?:
+        \s*:
+        \s*{{identifier}}
+      )?
+      \s*=>
+    )
+
   class_element_name: |-
     (?x)\+?(?:
       {{property_name}}


### PR DESCRIPTION
Partial fix for #29. This heuristic should be improved to work in most cases; however, it cannot solve the problem in the general case.

If [nondeterministic parsing](https://github.com/SublimeTextIssues/Core/issues/2241) is ever implemented, we can use that to fix the issue properly.