### PR TITLE
Enable emmet completions in styled-components

### DIFF
--- a/extensions/styled_components.yaml
+++ b/extensions/styled_components.yaml
@@ -4,7 +4,7 @@
 !merge
 contexts: !merge
   expression-begin: !prepend
-    - match: (?=(?:styled|createGlobalStyle|injectGlobal|keyframes){{identifier_break}})
+    - match: (?=(?:styled|css|createGlobalStyle|injectGlobal|keyframes){{identifier_break}})
       set:
         - styled-component-end
         - styled-component-begin

--- a/extensions/styled_components.yaml
+++ b/extensions/styled_components.yaml
@@ -37,7 +37,7 @@ contexts: !merge
                   0: punctuation.definition.template-expression.begin.js
                 push:
                   - clear_scopes: true
-                  - meta_scope: soucre.js.react meta.template.expression.js
+                  - meta_scope: !format '{scope} meta.template.expression.js'
                   - meta_content_scope: source.js.embedded.expression
                   - match: '\}'
                     scope: punctuation.definition.template-expression.end.js

--- a/extensions/styled_components.yaml
+++ b/extensions/styled_components.yaml
@@ -4,7 +4,7 @@
 !merge
 contexts: !merge
   expression-begin: !prepend
-    - match: (?=(?:styled|injectGlobal|keyframes){{identifier_break}})
+    - match: (?=(?:styled|createGlobalStyle|injectGlobal|keyframes){{identifier_break}})
       set:
         - styled-component-end
         - styled-component-begin
@@ -23,7 +23,7 @@ contexts: !merge
             scope: punctuation.definition.string.template.end.js
             pop: true
           - include: immediately-pop
-        - - clear_scopes: 1
+        - - clear_scopes: true
           - meta_scope: source.css.embedded.js
           - include: immediately-pop
         - - match: ''
@@ -36,8 +36,8 @@ contexts: !merge
                 captures:
                   0: punctuation.definition.template-expression.begin.js
                 push:
-                  - clear_scopes: 1
-                  - meta_scope: meta.template.expression.js
+                  - clear_scopes: true
+                  - meta_scope: soucre.js.react meta.template.expression.js
                   - meta_content_scope: source.js.embedded.expression
                   - match: '\}'
                     scope: punctuation.definition.template-expression.end.js


### PR DESCRIPTION
This pull request fixes #46 and also adds `createGlobalStyle` to support styled-components v4.

**Problem**
As described by @hudochenkov in [this comment](https://github.com/Thom1729/Sublime-JS-Custom/issues/46#issuecomment-449530733), emmet abbreviation does not work inside styled-components.

**Proposed solution**
Emmet abbreviation do work when setting parent scope to css. We can do this by clearing entire scope when a template literal with styled-components is triggered and then re-adding js scope when styled-components block ends.

Thanks for creating such a great plugin @Thom1729 