### PR TITLE
Prevent core syntax from picking up custom tests.

### DIFF
--- a/tests/syntax_test_suites/base/syntax_test_js.js
+++ b/tests/syntax_test_suites/base/syntax_test_js.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
 import TheirClass from "./mypath";
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.js

--- a/tests/syntax_test_suites/base/syntax_test_js_bindings.js
+++ b/tests/syntax_test_suites/base/syntax_test_js_bindings.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
 
 // Variable declarations

--- a/tests/syntax_test_suites/base/syntax_test_js_regexp.js
+++ b/tests/syntax_test_suites/base/syntax_test_js_regexp.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
 /* LITERAL */
 

--- a/tests/syntax_test_suites/base/syntax_test_js_support_builtin.js
+++ b/tests/syntax_test_suites/base/syntax_test_js_support_builtin.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
     isNaN;
 //  ^^^^^ support.function - meta.function-call

--- a/tests/syntax_test_suites/base/syntax_test_js_support_console.js
+++ b/tests/syntax_test_suites/base/syntax_test_js_support_console.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
     console;
 //  ^^^^^^^ support.type.object.console

--- a/tests/syntax_test_suites/base/syntax_test_js_support_dom.js
+++ b/tests/syntax_test_suites/base/syntax_test_js_support_dom.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
     XMLHttpRequest;
 //  ^^^^^^^^^^^^^^ support.class.dom

--- a/tests/syntax_test_suites/base/syntax_test_js_support_node.js
+++ b/tests/syntax_test_suites/base/syntax_test_js_support_node.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/JavaScript/JavaScript.sublime-syntax"
 
     global;
 //  ^^^^^^ support.type.object.node

--- a/tests/syntax_test_suites/flow/syntax_test_flow.js
+++ b/tests/syntax_test_suites/flow/syntax_test_flow.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/User/JS Custom/Tests/flow/flow.sublime-syntax"
 
 /* Built-in types */
 

--- a/tests/syntax_test_suites/jsx/syntax_test_jsx.js
+++ b/tests/syntax_test_suites/jsx/syntax_test_jsx.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/User/JS Custom/Tests/jsx/jsx.sublime-syntax"
 
     <foo />;
 //  ^^^^^^^ meta.jsx meta.tag

--- a/tests/syntax_test_suites/pipeline/syntax_test_pipeline.js
+++ b/tests/syntax_test_suites/pipeline/syntax_test_pipeline.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/User/JS Custom/Tests/jsx/jsx.sublime-syntax"
 
 foo |> bar;
 //  ^^ keyword.operator.pipeline

--- a/tests/syntax_test_suites/slice/syntax_test_slice.js
+++ b/tests/syntax_test_suites/slice/syntax_test_slice.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/User/JS Custom/Tests/jsx/jsx.sublime-syntax"
 
 foo[1:2:3];
 // ^^^^^^^ meta.brackets


### PR DESCRIPTION
The JS Custom syntax tests were running for the core syntax, which was annoying.