### PR TITLE
Support custom templates with comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ Then, if you use “JS Custom - My Config” to highlight the following code, th
 const myStyle = style`div { color: red }`;
 ```
 
+##### `comments`: object
+
+Highlight tagged template literals based on a preceding block comment. Example configuration:
+
+```json
+{
+    "configurations": {
+        "My Config": {
+            "custom_templates": {
+                "comments": {
+                    "style": "scope:source.css"
+                }
+            }
+        }
+    }
+}
+```
+
+Example JavaScript:
+
+```js
+const myStyle = /*style*/`div { color: red }`;
+```
+
 ##### `styled_components`: boolean
 
 Highlight template string literals for [Styled Components](https://www.styled-components.com/).

--- a/extensions/custom_templates/custom_templates.syntax-extension
+++ b/extensions/custom_templates/custom_templates.syntax-extension
@@ -8,11 +8,18 @@ contexts: !merge
     - include: literal-string-template-custom-tags
     - include: styled-components
 
+  expression-begin: !prepend
+    # Keep the slow backreferences out of this frequently-used context.
+    - match: (?=`)
+      set:
+        - include: literal-string-template-custom-comments
+        - include: literal-string-template
+
   literal-string-template-custom-tags: !foreach
     in: !argument [tags, {}]
     as: [tag, include]
     value:
-      match: !format '{tag}(?=\s*`)'
+      match: !format '(?:{tag})(?=\s*`)'
       scope: variable.function.tagged-template.js
       set: !include_resource Packages/JSCustom/extensions/custom_templates/template.yaml
 
@@ -20,7 +27,7 @@ contexts: !merge
     in: !argument [comments, {}]
     as: [tag, include]
     value:
-      match: !format '/\*\s*{tag}\s*\*/(?=\s*`)'
+      match: !format '(?<=/\*(?:{tag})\*/)'
       scope: variable.function.tagged-template.js
       set: !include_resource Packages/JSCustom/extensions/custom_templates/template.yaml
 

--- a/tests/syntax_test_suites/templates/syntax_test_templates.js
+++ b/tests/syntax_test_suites/templates/syntax_test_templates.js
@@ -1,4 +1,3 @@
-// SYNTAX TEST "Packages/User/JS Custom/Tests/templates/templates.sublime-syntax"
 
     css`a { color: red; }`
 //  ^^^ variable.function.tagged-template
@@ -32,3 +31,11 @@
 //  ^ string.quoted.other punctuation.definition.string.begin
 //   ^^^^^^^^^^^ source.js.css - string
 //              ^ string.quoted.other punctuation.definition.string.end
+
+    /*css*/`a { color: red; }`
+//  ^^^^^^^ comment.block
+//         ^^^^^^^^^^^^^^^^^^^ meta.string
+//          ^^^^^^^^^^^^^^^^^ source.css - string
+    `div { color: blue; }`;
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.string
+//   ^^^^^^^^^^^^^^^^^^^^ source.css - string

--- a/tests/test_syntaxes.py
+++ b/tests/test_syntaxes.py
@@ -99,6 +99,9 @@ class TestSyntaxes(DeferrableTestCase):
                     'tags': {
                         'css': 'scope:source.css',
                     },
+                    'comments': {
+                        'css': 'scope:source.css',
+                    },
                     'styled_components': True,
                 }
             },


### PR DESCRIPTION
Closes #49.

I hate using lookbehinds, but doing it any other was was going to be a mess (which is why I hadn't already implemented this). I mitigated the potential performance hit by adding an extra context that will only be run on untagged template strings. The other downside is that no extra spacing is permitted (because lookbehinds must be fixed-width).