### PR TITLE
Fix error when auto-building after removing a configuration.

### DIFF
--- a/src/commands/build_syntaxes.py
+++ b/src/commands/build_syntaxes.py
@@ -21,24 +21,35 @@ class BuildJsCustomSyntaxesCommand(sublime_plugin.WindowCommand):
 
         configurations = get_configurations(get_settings())
 
-        for syntax_path in SYNTAXES_BUILD_PATH.glob('*.sublime-syntax'):
-            if syntax_path.stem not in configurations:
-                syntax_path.file_path().unlink()
+        to_delete = {
+            syntax_path.stem : syntax_path
+            for syntax_path in SYNTAXES_BUILD_PATH.glob('*.sublime-syntax')
+            if syntax_path.stem not in configurations
+        }
+        to_build = configurations
+
+        if versions is not None:
+            def filter_by_versions(d):
+                return {
+                    k:v
+                    for k,v in d.items()
+                    if k in versions
+                }
+            to_delete = filter_by_versions(to_delete)
+            to_build = filter_by_versions(to_build)
 
         try:
             SYNTAXES_BUILD_PATH.file_path().mkdir(parents=True)
         except FileExistsError:
             pass
 
-        if versions:
-            configurations = {
-                name: configurations[name]
-                for name in versions
-                if name in configurations
-            }
-
         def run():
-            for name, configuration in configurations.items():
+            for name, syntax_path in to_delete.items():
+                print('JS Custom: Deleting configuration {}…'.format(name))
+                syntax_path.file_path().unlink()
+
+            for name, configuration in to_build.items():
+                print('JS Custom: Building configuration {}…'.format(name))
                 destination_path = (SYNTAXES_BUILD_PATH / (name + '.sublime-syntax')).file_path()
                 build_configuration(name, configuration, destination_path, output)
 

--- a/src/commands/build_syntaxes.py
+++ b/src/commands/build_syntaxes.py
@@ -34,6 +34,7 @@ class BuildJsCustomSyntaxesCommand(sublime_plugin.WindowCommand):
             configurations = {
                 name: configurations[name]
                 for name in versions
+                if name in configurations
             }
 
         def run():


### PR DESCRIPTION
When you modify your preferences, and `auto_build` is enabled, then JS Custom will call the `build_js_custom_syntaxes` command with the names of the new/modified/deleted configurations. However, that command will try to rebuild deleted configurations, which will cause an error. This PR fixes that.