### PR TITLE
Implement automatic syntax reassignment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ If true, JS Custom will automatically rebuild your syntaxes when you modify your
 
 If true, when you run the `close_tag` command in a JavaScript file, this package's `jsx_close_tag` command will be invoked instead.
 
+### `reassign_when_deleting`: string or `false`
+
+When you remove a custom configuration, JS Custom will automatically find any views using that configuration and assign them to this default syntax so that Sublime won't show an error popup. You can set this setting to the path or scope of any syntax definition, or set it to `false` to disable the feature entirely.
+
 ## Syntax Options
 
 These options, specified in your `defaults` or in a named custom configuration, determine what features your custom syntaxes will have. Omitted options will be treated as `null`.

--- a/plugin.py
+++ b/plugin.py
@@ -12,6 +12,7 @@ from .src.configurations import get_configurations
 from .src.commands.build_syntaxes import BuildJsCustomSyntaxCommand, BuildJsCustomSyntaxesCommand
 from .src.commands.build_tests import BuildJsCustomTestsCommand
 from .src.commands.clear_user_data import ClearJsCustomUserDataCommand
+from .src.commands.reassign_syntaxes import ReassignSyntaxesCommand
 from .src.commands.jsx_close_tag import JsxCloseTagCommand
 from .src.listeners.jsx_close_tag import JsxCloseTagListener
 
@@ -22,6 +23,7 @@ __all__ = [
     'BuildJsCustomSyntaxCommand',
     'BuildJsCustomTestsCommand',
     'ClearJsCustomUserDataCommand',
+    'ReassignSyntaxesCommand',
     'JsxCloseTagCommand',
     'JsxCloseTagListener',
 ]

--- a/src/commands/build_syntaxes.py
+++ b/src/commands/build_syntaxes.py
@@ -1,7 +1,8 @@
+import sublime
 import sublime_plugin
 
 from threading import Thread
-from sublime_lib import OutputPanel
+from sublime_lib import OutputPanel, get_syntax_for_scope
 
 from ..settings import get_settings
 from ..paths import USER_DATA_PATH
@@ -19,7 +20,8 @@ class BuildJsCustomSyntaxesCommand(sublime_plugin.WindowCommand):
         output = OutputPanel.create(self.window, 'YAMLMacros')
         output.show()
 
-        configurations = get_configurations(get_settings())
+        settings = get_settings()
+        configurations = get_configurations(settings)
 
         to_delete = {
             syntax_path.stem : syntax_path
@@ -42,6 +44,19 @@ class BuildJsCustomSyntaxesCommand(sublime_plugin.WindowCommand):
             SYNTAXES_BUILD_PATH.file_path().mkdir(parents=True)
         except FileExistsError:
             pass
+
+        if settings.get('reassign_when_deleting', False):
+            replacement = settings['reassign_when_deleting']
+            if replacement.startswith('scope:'):
+                replacement = get_syntax_for_scope(replacement[6:])
+
+            paths_to_delete = [str(path) for path in to_delete.values()]
+
+            print(paths_to_delete, replacement)
+            sublime.run_command('reassign_syntaxes', {
+                'syntaxes': paths_to_delete,
+                'replacement': replacement,
+            })
 
         def run():
             for name, syntax_path in to_delete.items():

--- a/src/commands/reassign_syntaxes.py
+++ b/src/commands/reassign_syntaxes.py
@@ -1,0 +1,17 @@
+import sublime
+import sublime_plugin
+
+__all__ = ['ReassignSyntaxesCommand']
+
+
+class ReassignSyntaxesCommand(sublime_plugin.ApplicationCommand):
+    def run(self, syntaxes, replacement):
+        for window in sublime.windows():
+            for view in window.views():
+                settings = view.settings()
+                if settings.get('syntax') in syntaxes:
+                    print('replacing {} with {}'.format(
+                        settings.get('syntax'),
+                        replacement
+                    ))
+                    settings.set('syntax', replacement)

--- a/sublime/JS Custom.sublime-settings
+++ b/sublime/JS Custom.sublime-settings
@@ -24,5 +24,6 @@
     },
 
     "auto_build": true,
-    "jsx_close_tag": true
+    "jsx_close_tag": true,
+    "reassign_when_deleting": "scope:source.js",
 }


### PR DESCRIPTION
Before deleting a compiled syntax, find any views using that syntax and reassign them to a different one (by default, whatever matches `scope:source.js`). This avoids an annoying modal error message from Sublime.