### PR TITLE
Support TypeScript scopes for comments and tag closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ An object specifying a configuration to use when another syntax embeds the `sour
 
 If true, JS Custom will automatically rebuild your syntaxes when you modify your user settings. Only syntaxes whose configurations have changed will be rebuilt. If `auto_build` is disabled, you will have to run the rebuild command manually.
 
-### `jsx_close_tag`: boolean
+### `jsx_close_tag`: string or boolean
 
-If true, when you run the `close_tag` command in a JavaScript file, this package's `jsx_close_tag` command will be invoked instead.
+When you run the `close_tag` command, if the scope of the file matches this selector, then this package's `jsx_close_tag` command will be invoked instead. You may have to modify this setting if you use the `scope` configuration option
+
+If false, `jsx_close_tag` will never be run.
 
 ### `reassign_when_deleting`: string or `false`
 

--- a/src/listeners/jsx_close_tag.py
+++ b/src/listeners/jsx_close_tag.py
@@ -8,9 +8,15 @@ __all__ = ['JsxCloseTagListener']
 
 class JsxCloseTagListener(sublime_plugin.ViewEventListener):
     def on_text_command(self, command_name, args):
-        if (
-            command_name == 'close_tag'
-            and get_settings()['jsx_close_tag']
-            and self.view.match_selector(0, 'source.js')
-        ):
+        if command_name != 'close_tag':
+            return
+
+        selector = get_settings()['jsx_close_tag']
+
+        if not selector:
+            return
+        elif selector is True:
+            selector = 'source.js, source.ts, source.tsx'
+
+        if self.view.match_selector(0, selector):
             return ('jsx_close_tag', args)

--- a/sublime/JS Custom - Comments.tmPreferences
+++ b/sublime/JS Custom - Comments.tmPreferences
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>name</key>
-    <string>JS Custom - JSX Comments</string>
+    <string>Comments</string>
     <key>scope</key>
-    <string>source.js meta.jsx - source.js.embedded.jsx, source.tsx meta.jsx - source.tsx.embedded.jsx</string>
+    <string>source.js, source.ts, source.tsx</string>
     <key>settings</key>
     <dict>
         <key>shellVariables</key>
@@ -14,13 +13,19 @@
                 <key>name</key>
                 <string>TM_COMMENT_START</string>
                 <key>value</key>
-                <string>{/*</string>
+                <string>// </string>
             </dict>
             <dict>
                 <key>name</key>
-                <string>TM_COMMENT_END</string>
+                <string>TM_COMMENT_START_2</string>
                 <key>value</key>
-                <string>*/}</string>
+                <string>/*</string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_END_2</string>
+                <key>value</key>
+                <string>*/</string>
             </dict>
         </array>
     </dict>

--- a/sublime/JS Custom - JSX Comments.tmPreferences
+++ b/sublime/JS Custom - JSX Comments.tmPreferences
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>JS Custom - JSX Comments</string>
     <key>scope</key>
-    <string>source.js meta.jsx - source.js.embedded.jsx, source.tsx meta.jsx - source.tsx.embedded.jsx</string>
+    <string>source.js meta.jsx - source.js.embedded.jsx, source.ts meta.jsx - source.ts.embedded.jsx, source.tsx meta.jsx - source.tsx.embedded.jsx</string>
     <key>settings</key>
     <dict>
         <key>shellVariables</key>

--- a/sublime/JS Custom.sublime-settings
+++ b/sublime/JS Custom.sublime-settings
@@ -37,6 +37,6 @@
     },
 
     "auto_build": true,
-    "jsx_close_tag": true,
+    "jsx_close_tag": "source.js, source.ts, source.tsx",
     "reassign_when_deleting": "scope:source.js",
 }


### PR DESCRIPTION
The core JavaScript syntax uses the top-level scope `source.js`, and various features (such as the `toggle_comment` command) rely on that. JS Custom syntaxes default to more detailed top-level scopes like `source.js.myconfiguration`, which should work just as well. However, if you use the `scope` option to specify a custom scope like `source.ts` (e.g. for compatibility with other tools), then `toggle_comment` won't work (see #98).

This PR patches this problem for the common case by:

- Explicitly defining JS-style comments for the `source.js`, `source.ts`, and `source.tsx` scopes.
- Explicitly defining JSX comments for the `source.js`, `source.ts`, and `source.tsx` scopes.
- Modifying the automatic `jsx_close_tag` functionality to match the selector `source.js, source.ts, source.tsx`.

This should work well for most people in most cases. However, it's not a perfect solution:

- Hardcoded scopes won't work for other custom scopes. (I can't think of a reason to specify a custom scope not on the list, but I'm sure there's a reason out there.)
- These hardcoded values could theoretically conflict with another package; for instance, if someone is using JS Custom alongside a dedicated TypeScript package. I think this probably shouldn't cause problems, but I can't rule it out.

I'll probably merge this for now, but in the long run I'll be looking at alternatives. One option is dynamically generating `tmPreferences` files alongside the compiled syntaxes. If I go that route, it probably won't be before v3.0.