### PR TITLE
Recipe Examples for Apollo / Prisma / GraphQL

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -2,6 +2,14 @@
 
 These example configurations are designed to support common use cases. You can customize these configurations or combine options from several, or you can create multiple configurations for different projects or use cases.
 
+- [JSX](#jsx)
+- [TypeScript](#typescript)
+- [TSX](#tsx)
+- [Styled Components](#styled-components)
+- [Emotion.js](#emotionjs)
+- [Apollo / Prisma / GraphQL gql Tag](#apollo-prisma-graphql-gql-tag)
+- [Highlight HTML in template strings](#highlight-html-in-template-strings)
+
 ## JSX
 
 ```json

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -84,7 +84,7 @@ you need to also install Sublime Text package for GraphQL syntax definition.
 ```json
 {
     "configurations": {
-        "Emotion.js Recipe": {
+        "GraphQL Recipe": {
             "custom_templates": {
                 // if you use something like:
                 // const fragment = gql`

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -77,6 +77,37 @@ For Styled Components version 5.
 }
 ```
 
+## Apollo / Prisma / GraphQL gql Tag
+
+you need to also install Sublime Text package for GraphQL syntax definition.
+
+```json
+{
+    "configurations": {
+        "Emotion.js Recipe": {
+            "custom_templates": {
+                // if you use something like:
+                // const fragment = gql`
+                //     fragment User on User {
+                //     ...
+                // `;
+                "tags": {
+                    "gql": "scope:source.graphql",
+                },
+                // if you use something like:
+                // const fragment = /* GraphQL */`
+                //     fragment User on User {
+                //     ...
+                // `;
+                "comments": {
+                    "GraphQL": "scope:source.graphql",
+                }
+            }
+        }
+    }
+}
+```
+
 ## Highlight HTML in template strings
 
 Highlight template strings as HTML if they begin with a `<`:

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -7,7 +7,7 @@ These example configurations are designed to support common use cases. You can c
 - [TSX](#tsx)
 - [Styled Components](#styled-components)
 - [Emotion.js](#emotionjs)
-- [Apollo / Prisma / GraphQL gql Tag](#apollo-prisma-graphql-gql-tag)
+- [Apollo / Prisma / GraphQL gql Tag](#apollo--prisma--graphql-gql-tag)
 - [Highlight HTML in template strings](#highlight-html-in-template-strings)
 
 ## JSX


### PR DESCRIPTION
add example of using this package to allow gql tag highlighting.

I made the example verbose with the intention so that user can understand the usage of `"tags"` or `"comments"` property of `"custom_templates"`.